### PR TITLE
Add session name to avoid possible conflicts with other apps

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -34,8 +34,15 @@ if( !ini_get('safe_mode') ){
 	set_time_limit($MaximumExecutionTime);
 	ini_set('max_execution_time',$MaximumExecutionTime);
 }
+
 session_write_close(); //in case a previous session is not closed
 ini_set('session.cookie_httponly',1);
+
+// Set a specific session_name to avoid potential default session_name conflicts
+// with other apps using the same host.
+// For an example situation to support this need, see:
+// http://www.weberp.org/forum/showthread.php?tid=8133
+session_name('PHPSESSIDwebERPteam');
 session_start();
 
 include($PathPrefix . 'includes/ConnectDB.inc');


### PR DESCRIPTION
Avoid potential session name conflicts with other apps on the same host that might use the same default session name.

An example situation to support this need can be found here:
http://www.weberp.org/forum/showthread.php?tid=8133