### PR TITLE
Use inline-block instead of inline

### DIFF
--- a/css/WEBootstrap/default.css
+++ b/css/WEBootstrap/default.css
@@ -389,7 +389,7 @@ select.selecterror {
 	filter:progid:DXImageTransform.Microsoft.Shadow(Strength=1, Direction=135, Color='#C3C3C3');
 }
 #QuickMenuDiv li {
-	display:inline-block; /* items are inline */
+	display:inline-block;
 	height:38px;
 }
 

--- a/css/aguapop/default.css
+++ b/css/aguapop/default.css
@@ -305,9 +305,9 @@ li {
 	list-style:none;
 	float:right;
 }
-#QuickMenuDiv ul li {
+#QuickMenuDiv li {
+	display:inline-block;
 	float:left;
-	display:inline;
 	margin:0px 3px;
 }
 

--- a/css/default/default.css
+++ b/css/default/default.css
@@ -21,11 +21,11 @@ button img {
 }
 
 a {
-	color:blue;
+	color:#0000ff;
 	text-decoration:none;
 }
 a:hover {
-	color:blue;
+	color:#0000ff;
 	background-color:transparent;
 	text-decoration:underline;
 	/* Tag selector for mouse over link. */
@@ -34,7 +34,7 @@ a:hover {
 img {
 	border:none;
 	vertical-align:middle;
-}
+}color:#ffffff;
 p.bad {
 	color:red;
 	font-weight:bold;
@@ -59,7 +59,7 @@ table.selection {
 
 th {
 	background-color:#b06161;
-	color:white;
+	color:#ffffff;
 	font-weight:normal;
 }
 
@@ -230,7 +230,7 @@ tr.striped_row:nth-of-type(odd) {
 .tableheader {
 	font-weight:normal;
 	background-color:#800000;
-	color:white;
+	color:#ffffff;
 }
 
 .notavailable {
@@ -271,7 +271,7 @@ textarea.texterror {
 
 .OsRow {
 	background-color:#234567;
-	color:white;
+	color:#ffffff;
 }
 
 /*** CANVAS ***/
@@ -283,13 +283,13 @@ textarea.texterror {
 /*** HEADER ***/
 
 #HeaderDiv {
-	color:white;
+	color:#ffffff;
 	/*background:#588BB6;*/
 	/*overflow:hidden;*/
 }
 
 #HeaderDiv a {
-	color:white;
+	color:#ffffff;
 }
 
 #HeaderDiv a:hover {
@@ -327,8 +327,8 @@ textarea.texterror {
 }
 
 #QuickMenuDiv li {
-	display:inline;
 	border-left:thin ridge #588BB6;
+	display:inline-block;
 	padding:14px 12px;
 }
 
@@ -384,7 +384,7 @@ textarea.texterror {
 }
 
 .main_menu_selected {
-	background-color:white;
+	background-color:#ffffff;
 	padding:2px;
 }
 
@@ -411,11 +411,11 @@ textarea.texterror {
 }
 
 #SubMenuDiv a {
-	color:blue;
+	color:#0000ff;
 }
 
 #SubMenuDiv a:hover {
-	color:blue;
+	color:#0000ff;
 	text-decoration:underline;
 }
 
@@ -433,7 +433,7 @@ textarea.texterror {
 }
 
 .menu_group_item {
-	background-color:white;
+	background-color:#ffffff;
 	padding:2px;
 }
 

--- a/css/default/default.css
+++ b/css/default/default.css
@@ -34,7 +34,7 @@ a:hover {
 img {
 	border:none;
 	vertical-align:middle;
-}color:#ffffff;
+}
 p.bad {
 	color:red;
 	font-weight:bold;

--- a/css/fluid/default.css
+++ b/css/fluid/default.css
@@ -317,7 +317,7 @@ list-style-image:url(bullet.gif);
 }
 #MainMenuDiv ul {list-style:none;padding:0;margin:0;}
 #MainMenuDiv li {
-	display:inline-block;
+	display:inline;
 	float:left;
 	margin:2px 0;
 	padding:0;}

--- a/css/fluid/default.css
+++ b/css/fluid/default.css
@@ -282,7 +282,12 @@ list-style-image:url(bullet.gif);
 
 #QuickMenuDiv {float:right;}
 #QuickMenuDiv ul {list-style:none;margin:0;padding:0;}
-#QuickMenuDiv li {display:inline;float:left;margin:2px 0;padding:0;}
+#QuickMenuDiv li {
+	display:inline-block;
+	float:left;
+	margin:2px 0;
+	padding:0;
+}
 #QuickMenuDiv li a {
 	background:#aae;
 	border:1px outset #aae;
@@ -311,7 +316,11 @@ list-style-image:url(bullet.gif);
 	height:18px;
 }
 #MainMenuDiv ul {list-style:none;padding:0;margin:0;}
-#MainMenuDiv li {display:inline;float:left;margin:2px 0;padding:0;}
+#MainMenuDiv li {
+	display:inline-block;
+	float:left;
+	margin:2px 0;
+	padding:0;}
 #MainMenuDiv li a {
 	background:#aae;
 	border:1px outset #aae;

--- a/css/fresh/default.css
+++ b/css/fresh/default.css
@@ -312,7 +312,7 @@ select.selecterror {
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 }
 
 /*** links as buttons!!! clicking anywhere in the button will activate

--- a/css/gel/default.css
+++ b/css/gel/default.css
@@ -327,7 +327,7 @@ li { /* ??? */
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 }
 
 /*** links as buttons!!! clicking anywhere in the button will activate

--- a/css/professional-rtl/default.css
+++ b/css/professional-rtl/default.css
@@ -369,7 +369,7 @@ li {
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 	float:right; /* right to left */
 }
 

--- a/css/professional/default.css
+++ b/css/professional/default.css
@@ -352,7 +352,7 @@ textarea.texterror {
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 }
 
 /*** links as buttons!!! clicking anywhere in the button will activate

--- a/css/silverwolf/default.css
+++ b/css/silverwolf/default.css
@@ -338,7 +338,7 @@ select.selecterror { /*AccountGroups.php, BankAccounts.php, BOMs.php, Stocks.php
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 }
 
 /*** links as buttons!!! clicking anywhere in the button will activate

--- a/css/wood/default.css
+++ b/css/wood/default.css
@@ -355,7 +355,7 @@ select.selecterror {
 	list-style:none; /* hide the bullets */
 }
 #QuickMenuDiv li {
-	display:inline; /* items are inline */
+	display:inline-block;
 }
 
 /* BODY */

--- a/css/xenos/default.css
+++ b/css/xenos/default.css
@@ -11,19 +11,18 @@ NOTE:
 This CSS is not yet fully optimized. Some styles maybe redundant and not supported by some browser.
 ***/
 
-
-button img {
-	/* Describes how button image should be displayed. */
-	height:21px;
-	width:21px;
-}
-
 body {
 	font-family:Arial, Verdana, Helvetica, sans-serif;
 	font-size:10pt;
 	margin:0;
 	padding:0;
 	background:#F1F1F1;
+}
+
+button img {
+	height:21px;
+	width:21px;
+	/* Describes how button image should be displayed. Related with body font-size in px. */
 }
 
 /*** Default Styles ***/
@@ -405,7 +404,7 @@ select.selecterror {
 	filter:progid:DXImageTransform.Microsoft.Shadow(Strength=1, Direction=135, Color='#C3C3C3');
 }
 #QuickMenuDiv li {
-	display:inline-block; /* items are inline */
+	display:inline-block;
 	height:38px;
 }
 


### PR DESCRIPTION
Use inline-block instead of inline in #QuickMenuDiv li to displays elements as an inline-level block container (with height and width). Useful in small devices.