### PR TITLE
replaced curly braces in PHPExcel for PHP 8 compat

### DIFF
--- a/Classes/PHPExcel/Calculation.php
+++ b/Classes/PHPExcel/Calculation.php
@@ -2185,7 +2185,7 @@ class PHPExcel_Calculation {
 	 */
 	public static function _unwrapResult($value) {
 		if (is_string($value)) {
-			if ((isset($value{0})) && ($value{0} == '"') && (substr($value,-1) == '"')) {
+			if ((isset($value[0])) && ($value[0] == '"') && (substr($value,-1) == '"')) {
 				return substr($value,1,-1);
 			}
 		//	Convert numeric errors to NaN error
@@ -2301,7 +2301,7 @@ class PHPExcel_Calculation {
 		//	Basic validation that this is indeed a formula
 		//	We return an empty array if not
 		$formula = trim($formula);
-		if ((!isset($formula{0})) || ($formula{0} != '=')) return array();
+		if ((!isset($formula[0])) || ($formula[0] != '=')) return array();
 		$formula = ltrim(substr($formula,1));
 		if (!isset($formula{0})) return array();
 
@@ -2379,9 +2379,9 @@ class PHPExcel_Calculation {
 		//	Basic validation that this is indeed a formula
 		//	We simply return the cell value if not
 		$formula = trim($formula);
-		if ($formula{0} != '=') return self::_wrapResult($formula);
+		if ($formula[0] != '=') return self::_wrapResult($formula);
 		$formula = ltrim(substr($formula,1));
-		if (!isset($formula{0})) return self::_wrapResult($formula);
+		if (!isset($formula[0])) return self::_wrapResult($formula);
 
 		$pCellParent = ($pCell !== NULL) ? $pCell->getWorksheet() : NULL;
 		$wsTitle = ($pCellParent !== NULL) ? $pCellParent->getTitle() : "\x00Wrk";
@@ -2390,7 +2390,7 @@ class PHPExcel_Calculation {
 			return $cellValue;
 		}
 
-		if (($wsTitle{0} !== "\x00") && ($this->_cyclicReferenceStack->onStack($wsTitle.'!'.$cellID))) {
+		if (($wsTitle[0] !== "\x00") && ($this->_cyclicReferenceStack->onStack($wsTitle.'!'.$cellID))) {
 			if ($this->cyclicFormulaCount <= 0) {
 				return $this->_raiseFormulaError('Cyclic Reference in Formula');
 			} elseif (($this->_cyclicFormulaCount >= $this->cyclicFormulaCount) &&
@@ -2639,7 +2639,7 @@ class PHPExcel_Calculation {
 			} else {
 				if ($value == '') {
 					return 'an empty string';
-				} elseif ($value{0} == '#') {
+				} elseif ($value[0] == '#') {
 					return 'a '.$value.' error';
 				} else {
 					$typeString = 'a string';
@@ -2768,10 +2768,10 @@ class PHPExcel_Calculation {
 		//	Loop through the formula extracting each operator and operand in turn
 		while(TRUE) {
 //echo 'Assessing Expression '.substr($formula, $index),PHP_EOL;
-			$opCharacter = $formula{$index};	//	Get the first character of the value at the current index position
+			$opCharacter = $formula[$index];	//	Get the first character of the value at the current index position
 //echo 'Initial character of expression block is '.$opCharacter,PHP_EOL;
-			if ((isset(self::$_comparisonOperators[$opCharacter])) && (strlen($formula) > $index) && (isset(self::$_comparisonOperators[$formula{$index+1}]))) {
-				$opCharacter .= $formula{++$index};
+			if ((isset(self::$_comparisonOperators[$opCharacter])) && (strlen($formula) > $index) && (isset(self::$_comparisonOperators[$formula[$index+1]]))) {
+				$opCharacter .= $formula[++$index];
 //echo 'Initial character of expression block is comparison operator '.$opCharacter.PHP_EOL;
 			}
 
@@ -3046,11 +3046,11 @@ class PHPExcel_Calculation {
 				}
 			}
 			//	Ignore white space
-			while (($formula{$index} == "\n") || ($formula{$index} == "\r")) {
+			while (($formula[$index] == "\n") || ($formula[$index] == "\r")) {
 				++$index;
 			}
-			if ($formula{$index} == ' ') {
-				while ($formula{$index} == ' ') {
+			if ($formula[$index] == ' ') {
+				while ($formula[$index] == ' ') {
 					++$index;
 				}
 				//	If we're expecting an operator, but only have a space between the previous and next operands (and both are
@@ -3466,7 +3466,7 @@ class PHPExcel_Calculation {
 //					echo 'Token is a PHPExcel constant: '.$excelConstant.'<br />';
 					$stack->push('Constant Value',self::$_ExcelConstants[$excelConstant]);
 					$this->_debugLog->writeDebugLog('Evaluating Constant ', $excelConstant, ' as ', $this->_showTypeDetails(self::$_ExcelConstants[$excelConstant]));
-				} elseif ((is_numeric($token)) || ($token === NULL) || (is_bool($token)) || ($token == '') || ($token{0} == '"') || ($token{0} == '#')) {
+				} elseif ((is_numeric($token)) || ($token === NULL) || (is_bool($token)) || ($token == '') || ($token[0] == '"') || ($token[0] == '#')) {
 //					echo 'Token is a number, boolean, string, null or an Excel error<br />';
 					$stack->push('Value',$token);
 				// if the token is a named range, push the named range name onto the stack
@@ -3508,11 +3508,11 @@ class PHPExcel_Calculation {
 		if (is_string($operand)) {
 			//	We only need special validations for the operand if it is a string
 			//	Start by stripping off the quotation marks we use to identify true excel string values internally
-			if ($operand > '' && $operand{0} == '"') { $operand = self::_unwrapResult($operand); }
+			if ($operand > '' && $operand[0] == '"') { $operand = self::_unwrapResult($operand); }
 			//	If the string is a numeric value, we treat it as a numeric, so no further testing
 			if (!is_numeric($operand)) {
 				//	If not a numeric, test to see if the value is an Excel error, and so can't be used in normal binary operations
-				if ($operand > '' && $operand{0} == '#') {
+				if ($operand > '' && $operand[0] == '#') {
 					$stack->push('Value', $operand);
 					$this->_debugLog->writeDebugLog('Evaluation Result is ', $this->_showTypeDetails($operand));
 					return FALSE;
@@ -3565,8 +3565,8 @@ class PHPExcel_Calculation {
 		}
 
 		//	Simple validate the two operands if they are string values
-		if (is_string($operand1) && $operand1 > '' && $operand1{0} == '"') { $operand1 = self::_unwrapResult($operand1); }
-		if (is_string($operand2) && $operand2 > '' && $operand2{0} == '"') { $operand2 = self::_unwrapResult($operand2); }
+		if (is_string($operand1) && $operand1 > '' && $operand1[0] == '"') { $operand1 = self::_unwrapResult($operand1); }
+		if (is_string($operand2) && $operand2 > '' && $operand2[0] == '"') { $operand2 = self::_unwrapResult($operand2); }
 
 		// Use case insensitive comparaison if not OpenOffice mode
 		if (PHPExcel_Calculation_Functions::getCompatibilityMode() != PHPExcel_Calculation_Functions::COMPATIBILITY_OPENOFFICE)

--- a/Classes/PHPExcel/Calculation/Engineering.php
+++ b/Classes/PHPExcel/Calculation/Engineering.php
@@ -708,7 +708,7 @@ class PHPExcel_Calculation_Engineering {
 		//	Split the input into its Real and Imaginary components
 		$leadingSign = 0;
 		if (strlen($workString) > 0) {
-			$leadingSign = (($workString{0} == '+') || ($workString{0} == '-')) ? 1 : 0;
+			$leadingSign = (($workString[0] == '+') || ($workString[0] == '-')) ? 1 : 0;
 		}
 		$power = '';
 		$realNumber = strtok($workString, '+-');
@@ -747,10 +747,10 @@ class PHPExcel_Calculation_Engineering {
 	 * @return	string		The "cleaned" complex number
 	 */
 	private static function _cleanComplex($complexNumber) {
-		if ($complexNumber{0} == '+') $complexNumber = substr($complexNumber,1);
-		if ($complexNumber{0} == '0') $complexNumber = substr($complexNumber,1);
-		if ($complexNumber{0} == '.') $complexNumber = '0'.$complexNumber;
-		if ($complexNumber{0} == '+') $complexNumber = substr($complexNumber,1);
+		if ($complexNumber[0] == '+') $complexNumber = substr($complexNumber,1);
+		if ($complexNumber[0] == '0') $complexNumber = substr($complexNumber,1);
+		if ($complexNumber[0] == '.') $complexNumber = '0'.$complexNumber;
+		if ($complexNumber[0] == '+') $complexNumber = substr($complexNumber,1);
 		return $complexNumber;
 	}
 

--- a/Classes/PHPExcel/Calculation/FormulaParser.php
+++ b/Classes/PHPExcel/Calculation/FormulaParser.php
@@ -159,7 +159,7 @@ class PHPExcel_Calculation_FormulaParser {
 
 		// Check if the formula has a valid starting =
 		$formulaLength = strlen($this->_formula);
-		if ($formulaLength < 2 || $this->_formula{0} != '=') return;
+		if ($formulaLength < 2 || $this->_formula[0] != '=') return;
 
 		// Helper variables
 		$tokens1	= $tokens2 	= $stack = array();
@@ -179,8 +179,8 @@ class PHPExcel_Calculation_FormulaParser {
 			// embeds are doubled
 			// end marks token
 			if ($inString) {
-				if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE) {
-					if ((($index + 2) <= $formulaLength) && ($this->_formula{$index + 1} == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE)) {
+				if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE) {
+					if ((($index + 2) <= $formulaLength) && ($this->_formula[$index + 1] == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE)) {
 						$value .= PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE;
 						++$index;
 					} else {
@@ -189,7 +189,7 @@ class PHPExcel_Calculation_FormulaParser {
 						$value = "";
 					}
 				} else {
-					$value .= $this->_formula{$index};
+					$value .= $this->_formula[$index];
 				}
 				++$index;
 				continue;
@@ -199,15 +199,15 @@ class PHPExcel_Calculation_FormulaParser {
 			// embeds are double
 			// end does not mark a token
 			if ($inPath) {
-				if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE) {
-					if ((($index + 2) <= $formulaLength) && ($this->_formula{$index + 1} == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE)) {
+				if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE) {
+					if ((($index + 2) <= $formulaLength) && ($this->_formula[$index + 1] == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE)) {
 						$value .= PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE;
 						++$index;
 					} else {
 						$inPath = false;
 					}
 				} else {
-					$value .= $this->_formula{$index};
+					$value .= $this->_formula[$index];
 				}
 				++$index;
 				continue;
@@ -217,10 +217,10 @@ class PHPExcel_Calculation_FormulaParser {
 			// no embeds (changed to "()" by Excel)
 			// end does not mark a token
 			if ($inRange) {
-				if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::BRACKET_CLOSE) {
+				if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::BRACKET_CLOSE) {
 					$inRange = false;
 				}
-				$value .= $this->_formula{$index};
+				$value .= $this->_formula[$index];
 				++$index;
 				continue;
 			}
@@ -228,7 +228,7 @@ class PHPExcel_Calculation_FormulaParser {
 			// error values
 			// end marks a token, determined from absolute list of values
 			if ($inError) {
-				$value .= $this->_formula{$index};
+				$value .= $this->_formula[$index];
 				++$index;
 				if (in_array($value, $ERRORS)) {
 					$inError = false;
@@ -239,10 +239,10 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// scientific notation check
-			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_SN, $this->_formula{$index}) !== false) {
+			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_SN, $this->_formula[$index]) !== false) {
 				if (strlen($value) > 1) {
-					if (preg_match("/^[1-9]{1}(\.[0-9]+)?E{1}$/", $this->_formula{$index}) != 0) {
-						$value .= $this->_formula{$index};
+					if (preg_match("/^[1-9]{1}(\.[0-9]+)?E{1}$/", $this->_formula[$index]) != 0) {
+						$value .= $this->_formula[$index];
 						++$index;
 						continue;
 					}
@@ -252,7 +252,7 @@ class PHPExcel_Calculation_FormulaParser {
 			// independent character evaluation (order not important)
 
 			// establish state-dependent character evaluations
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::QUOTE_DOUBLE) {
 				if (strlen($value > 0)) {  // unexpected
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_UNKNOWN);
 					$value = "";
@@ -262,7 +262,7 @@ class PHPExcel_Calculation_FormulaParser {
 				continue;
  			}
 
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::QUOTE_SINGLE) {
 				if (strlen($value) > 0) { // unexpected
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_UNKNOWN);
 					$value = "";
@@ -272,14 +272,14 @@ class PHPExcel_Calculation_FormulaParser {
 				continue;
 			}
 
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::BRACKET_OPEN) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::BRACKET_OPEN) {
 				$inRange = true;
 				$value .= PHPExcel_Calculation_FormulaParser::BRACKET_OPEN;
 				++$index;
 				continue;
 			}
 
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::ERROR_START) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::ERROR_START) {
 				if (strlen($value) > 0) { // unexpected
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_UNKNOWN);
 					$value = "";
@@ -291,7 +291,7 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// mark start and end of arrays and array rows
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::BRACE_OPEN) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::BRACE_OPEN) {
 				if (strlen($value) > 0) { // unexpected
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_UNKNOWN);
 					$value = "";
@@ -309,7 +309,7 @@ class PHPExcel_Calculation_FormulaParser {
 				continue;
 			}
 
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::SEMICOLON) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::SEMICOLON) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
@@ -331,7 +331,7 @@ class PHPExcel_Calculation_FormulaParser {
 				continue;
 			}
 
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::BRACE_CLOSE) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::BRACE_CLOSE) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
@@ -352,14 +352,14 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// trim white-space
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::WHITESPACE) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::WHITESPACE) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
 				}
 				$tokens1[] = new PHPExcel_Calculation_FormulaToken("", PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_WHITESPACE);
 				++$index;
-				while (($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::WHITESPACE) && ($index < $formulaLength)) {
+				while (($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::WHITESPACE) && ($index < $formulaLength)) {
 					++$index;
 				}
 				continue;
@@ -379,29 +379,29 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// standard infix operators
-			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_INFIX, $this->_formula{$index}) !== false) {
+			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_INFIX, $this->_formula[$index]) !== false) {
 				if (strlen($value) > 0) {
 					$tokens1[] =new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
 				}
-				$tokens1[] = new PHPExcel_Calculation_FormulaToken($this->_formula{$index}, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERATORINFIX);
+				$tokens1[] = new PHPExcel_Calculation_FormulaToken($this->_formula[$index], PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERATORINFIX);
 				++$index;
 				continue;
 			}
 
 			// standard postfix operators (only one)
-			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_POSTFIX, $this->_formula{$index}) !== false) {
+			if (strpos(PHPExcel_Calculation_FormulaParser::OPERATORS_POSTFIX, $this->_formula[$index]) !== false) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
 				}
-				$tokens1[] = new PHPExcel_Calculation_FormulaToken($this->_formula{$index}, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERATORPOSTFIX);
+				$tokens1[] = new PHPExcel_Calculation_FormulaToken($this->_formula[$index], PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERATORPOSTFIX);
 				++$index;
 				continue;
 			}
 
 			// start subexpression or function
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::PAREN_OPEN) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::PAREN_OPEN) {
 				if (strlen($value) > 0) {
 					$tmp = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_FUNCTION, PHPExcel_Calculation_FormulaToken::TOKEN_SUBTYPE_START);
 					$tokens1[] = $tmp;
@@ -417,7 +417,7 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// function, subexpression, or array parameters, or operand unions
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::COMMA) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::COMMA) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
@@ -438,7 +438,7 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
 			// stop subexpression
-			if ($this->_formula{$index} == PHPExcel_Calculation_FormulaParser::PAREN_CLOSE) {
+			if ($this->_formula[$index] == PHPExcel_Calculation_FormulaParser::PAREN_CLOSE) {
 				if (strlen($value) > 0) {
 					$tokens1[] = new PHPExcel_Calculation_FormulaToken($value, PHPExcel_Calculation_FormulaToken::TOKEN_TYPE_OPERAND);
 					$value = "";
@@ -454,7 +454,7 @@ class PHPExcel_Calculation_FormulaParser {
 			}
 
         	// token accumulation
-			$value .= $this->_formula{$index};
+			$value .= $this->_formula[$index];
 			++$index;
 		}
 

--- a/Classes/PHPExcel/Calculation/Functions.php
+++ b/Classes/PHPExcel/Calculation/Functions.php
@@ -310,7 +310,7 @@ class PHPExcel_Calculation_Functions {
 		$condition	= PHPExcel_Calculation_Functions::flattenSingleValue($condition);
 		if (!isset($condition{0}))
 			$condition = '=""';
-		if (!in_array($condition{0},array('>', '<', '='))) {
+		if (!in_array($condition[0],array('>', '<', '='))) {
 			if (!is_numeric($condition)) { $condition = PHPExcel_Calculation::_wrapResult(strtoupper($condition)); }
 			return '='.$condition;
 		} else {
@@ -531,7 +531,7 @@ class PHPExcel_Calculation_Functions {
 				break;
 			case 'string'	:
 				//	Errors
-				if ((strlen($value) > 0) && ($value{0} == '#')) {
+				if ((strlen($value) > 0) && ($value[0] == '#')) {
 					return $value;
 				}
 				break;
@@ -580,7 +580,7 @@ class PHPExcel_Calculation_Functions {
 				return 64;
 		} elseif(is_string($value)) {
 			//	Errors
-			if ((strlen($value) > 0) && ($value{0} == '#')) {
+			if ((strlen($value) > 0) && ($value[0] == '#')) {
 				return 16;
 			}
 			return 2;

--- a/Classes/PHPExcel/Calculation/TextData.php
+++ b/Classes/PHPExcel/Calculation/TextData.php
@@ -48,19 +48,19 @@ class PHPExcel_Calculation_TextData {
 	private static $_invalidChars = Null;
 
 	private static function _uniord($c) {
-		if (ord($c{0}) >=0 && ord($c{0}) <= 127)
-			return ord($c{0});
-		if (ord($c{0}) >= 192 && ord($c{0}) <= 223)
-			return (ord($c{0})-192)*64 + (ord($c{1})-128);
-		if (ord($c{0}) >= 224 && ord($c{0}) <= 239)
-			return (ord($c{0})-224)*4096 + (ord($c{1})-128)*64 + (ord($c{2})-128);
-		if (ord($c{0}) >= 240 && ord($c{0}) <= 247)
-			return (ord($c{0})-240)*262144 + (ord($c{1})-128)*4096 + (ord($c{2})-128)*64 + (ord($c{3})-128);
-		if (ord($c{0}) >= 248 && ord($c{0}) <= 251)
-			return (ord($c{0})-248)*16777216 + (ord($c{1})-128)*262144 + (ord($c{2})-128)*4096 + (ord($c{3})-128)*64 + (ord($c{4})-128);
-		if (ord($c{0}) >= 252 && ord($c{0}) <= 253)
-			return (ord($c{0})-252)*1073741824 + (ord($c{1})-128)*16777216 + (ord($c{2})-128)*262144 + (ord($c{3})-128)*4096 + (ord($c{4})-128)*64 + (ord($c{5})-128);
-		if (ord($c{0}) >= 254 && ord($c{0}) <= 255) //error
+		if (ord($c[0]) >=0 && ord($c[0]) <= 127)
+			return ord($c[0]);
+		if (ord($c[0]) >= 192 && ord($c[0]) <= 223)
+			return (ord($c[0])-192)*64 + (ord($c[1])-128);
+		if (ord($c[0]) >= 224 && ord($c[0]) <= 239)
+			return (ord($c[0])-224)*4096 + (ord($c[1])-128)*64 + (ord($c[2])-128);
+		if (ord($c[0]) >= 240 && ord($c[0]) <= 247)
+			return (ord($c[0])-240)*262144 + (ord($c[1])-128)*4096 + (ord($c[2])-128)*64 + (ord($c[3])-128);
+		if (ord($c[0]) >= 248 && ord($c[0]) <= 251)
+			return (ord($c[0])-248)*16777216 + (ord($c[1])-128)*262144 + (ord($c[2])-128)*4096 + (ord($c[3])-128)*64 + (ord($c[4])-128);
+		if (ord($c[0]) >= 252 && ord($c[0]) <= 253)
+			return (ord($c[0])-252)*1073741824 + (ord($c[1])-128)*16777216 + (ord($c[2])-128)*262144 + (ord($c[3])-128)*4096 + (ord($c[4])-128)*64 + (ord($c[5])-128);
+		if (ord($c[0]) >= 254 && ord($c[0]) <= 255) //error
 			return PHPExcel_Calculation_Functions::VALUE();
 		return 0;
 	}	//	function _uniord()

--- a/Classes/PHPExcel/Cell.php
+++ b/Classes/PHPExcel/Cell.php
@@ -813,10 +813,10 @@ class PHPExcel_Cell
 				$_indexCache[$pString] = $_columnLookup[$pString];
 				return $_indexCache[$pString];
 			} elseif(!isset($pString{2})) {
-				$_indexCache[$pString] = $_columnLookup[$pString{0}] * 26 + $_columnLookup[$pString{1}];
+				$_indexCache[$pString] = $_columnLookup[$pString[0]] * 26 + $_columnLookup[$pString[1]];
 				return $_indexCache[$pString];
 			} elseif(!isset($pString{3})) {
-				$_indexCache[$pString] = $_columnLookup[$pString{0}] * 676 + $_columnLookup[$pString{1}] * 26 + $_columnLookup[$pString{2}];
+				$_indexCache[$pString] = $_columnLookup[$pString[0]] * 676 + $_columnLookup[$pString[1]] * 26 + $_columnLookup[$pString[2]];
 				return $_indexCache[$pString];
 			}
 		}

--- a/Classes/PHPExcel/Cell/DefaultValueBinder.php
+++ b/Classes/PHPExcel/Cell/DefaultValueBinder.php
@@ -83,7 +83,7 @@ class PHPExcel_Cell_DefaultValueBinder implements PHPExcel_Cell_IValueBinder
         } elseif ($pValue instanceof PHPExcel_RichText) {
             return PHPExcel_Cell_DataType::TYPE_INLINE;
 
-        } elseif ($pValue{0} === '=' && strlen($pValue) > 1) {
+        } elseif ($pValue[0] === '=' && strlen($pValue) > 1) {
             return PHPExcel_Cell_DataType::TYPE_FORMULA;
 
         } elseif (is_bool($pValue)) {

--- a/Classes/PHPExcel/Reader/Excel2003XML.php
+++ b/Classes/PHPExcel/Reader/Excel2003XML.php
@@ -699,12 +699,12 @@ class PHPExcel_Reader_Excel2003XML extends PHPExcel_Reader_Abstract implements P
 												//	Empty R reference is the current row
 												if ($rowReference == '') $rowReference = $rowID;
 												//	Bracketed R references are relative to the current row
-												if ($rowReference{0} == '[') $rowReference = $rowID + trim($rowReference,'[]');
+												if ($rowReference[0] == '[') $rowReference = $rowID + trim($rowReference,'[]');
 												$columnReference = $cellReference[4][0];
 												//	Empty C reference is the current column
 												if ($columnReference == '') $columnReference = $columnNumber;
 												//	Bracketed C references are relative to the current column
-												if ($columnReference{0} == '[') $columnReference = $columnNumber + trim($columnReference,'[]');
+												if ($columnReference[0] == '[') $columnReference = $columnNumber + trim($columnReference,'[]');
 												$A1CellReference = PHPExcel_Cell::stringFromColumnIndex($columnReference-1).$rowReference;
 													$value = substr_replace($value,$A1CellReference,$cellReference[0][1],strlen($cellReference[0][0]));
 											}

--- a/Classes/PHPExcel/Reader/Excel5.php
+++ b/Classes/PHPExcel/Reader/Excel5.php
@@ -1860,7 +1860,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 		// offset: 0; size: 2; 0 = base 1900, 1 = base 1904
 		PHPExcel_Shared_Date::setExcelCalendar(PHPExcel_Shared_Date::CALENDAR_WINDOWS_1900);
-		if (ord($recordData{0}) == 1) {
+		if (ord($recordData[0]) == 1) {
 			PHPExcel_Shared_Date::setExcelCalendar(PHPExcel_Shared_Date::CALENDAR_MAC_1904);
 		}
 	}
@@ -1919,7 +1919,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			}
 
 			// offset: 10; size: 1; underline type
-			$underlineType = ord($recordData{10});
+			$underlineType = ord($recordData[10]);
 			switch ($underlineType) {
 				case 0x00:
 					break; // no underline
@@ -2058,7 +2058,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 			// offset:  6; size: 1; Alignment and text break
 			// bit 2-0, mask 0x07; horizontal alignment
-			$horAlign = (0x07 & ord($recordData{6})) >> 0;
+			$horAlign = (0x07 & ord($recordData[6])) >> 0;
 			switch ($horAlign) {
 				case 0:
 					$objStyle->getAlignment()->setHorizontal(PHPExcel_Style_Alignment::HORIZONTAL_GENERAL);
@@ -2083,7 +2083,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 					break;
 			}
 			// bit 3, mask 0x08; wrap text
-			$wrapText = (0x08 & ord($recordData{6})) >> 3;
+			$wrapText = (0x08 & ord($recordData[6])) >> 3;
 			switch ($wrapText) {
 				case 0:
 					$objStyle->getAlignment()->setWrapText(false);
@@ -2093,7 +2093,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 					break;
 			}
 			// bit 6-4, mask 0x70; vertical alignment
-			$vertAlign = (0x70 & ord($recordData{6})) >> 4;
+			$vertAlign = (0x70 & ord($recordData[6])) >> 4;
 			switch ($vertAlign) {
 				case 0:
 					$objStyle->getAlignment()->setVertical(PHPExcel_Style_Alignment::VERTICAL_TOP);
@@ -2111,7 +2111,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 			if ($this->_version == self::XLS_BIFF8) {
 				// offset:  7; size: 1; XF_ROTATION: Text rotation angle
-					$angle = ord($recordData{7});
+					$angle = ord($recordData[7]);
 					$rotation = 0;
 					if ($angle <= 90) {
 						$rotation = $angle;
@@ -2124,11 +2124,11 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 				// offset:  8; size: 1; Indentation, shrink to cell size, and text direction
 					// bit: 3-0; mask: 0x0F; indent level
-					$indent = (0x0F & ord($recordData{8})) >> 0;
+					$indent = (0x0F & ord($recordData[8])) >> 0;
 					$objStyle->getAlignment()->setIndent($indent);
 
 					// bit: 4; mask: 0x10; 1 = shrink content to fit into cell
-					$shrinkToFit = (0x10 & ord($recordData{8})) >> 4;
+					$shrinkToFit = (0x10 & ord($recordData[8])) >> 4;
 					switch ($shrinkToFit) {
 						case 0:
 							$objStyle->getAlignment()->setShrinkToFit(false);
@@ -2210,7 +2210,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 				// BIFF5
 
 				// offset: 7; size: 1; Text orientation and flags
-				$orientationAndFlags = ord($recordData{7});
+				$orientationAndFlags = ord($recordData[7]);
 
 				// bit: 1-0; mask: 0x03; XF_ORIENTATION: Text orientation
 				$xfOrientation = (0x03 & $orientationAndFlags) >> 0;
@@ -2334,7 +2334,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2350,7 +2350,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2366,7 +2366,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2382,7 +2382,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2398,7 +2398,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2414,7 +2414,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2430,7 +2430,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2446,7 +2446,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						$xclrValue = substr($extData, 4, 4); // color value (value based on color type)
 
 						if ($xclfType == 2) {
-							$rgb = sprintf('%02X%02X%02X', ord($xclrValue{0}), ord($xclrValue{1}), ord($xclrValue{2}));
+							$rgb = sprintf('%02X%02X%02X', ord($xclrValue[0]), ord($xclrValue[1]), ord($xclrValue[2]));
 
 							// modify the relevant style property
 							if ( isset($this->_mapCellXfIndex[$ixfe]) ) {
@@ -2488,7 +2488,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 			if ($isBuiltIn) {
 				// offset: 2; size: 1; identifier for built-in style
-				$builtInId = ord($recordData{2});
+				$builtInId = ord($recordData[2]);
 
 				switch ($builtInId) {
 				case 0x00:
@@ -2555,7 +2555,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		$this->_pos += 4 + $length;
 
 		// offset: 4; size: 1; sheet state
-		switch (ord($recordData{4})) {
+		switch (ord($recordData[4])) {
 			case 0x00: $sheetState = PHPExcel_Worksheet::SHEETSTATE_VISIBLE;    break;
 			case 0x01: $sheetState = PHPExcel_Worksheet::SHEETSTATE_HIDDEN;     break;
 			case 0x02: $sheetState = PHPExcel_Worksheet::SHEETSTATE_VERYHIDDEN; break;
@@ -2563,7 +2563,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		}
 
 		// offset: 5; size: 1; sheet type
-		$sheetType = ord($recordData{5});
+		$sheetType = ord($recordData[5]);
 
 		// offset: 6; size: var; sheet name
 		if ($this->_version == self::XLS_BIFF8) {
@@ -2742,7 +2742,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			// offset: 2; size: 1; keyboard shortcut
 
 			// offset: 3; size: 1; length of the name (character count)
-			$nlen = ord($recordData{3});
+			$nlen = ord($recordData[3]);
 
 			// offset: 4; size: 2; size of the formula data (it can happen that this is zero)
 			// note: there can also be additional data, this is not included in $flen
@@ -2826,7 +2826,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			$pos += 2;
 
 			// option flags
-			$optionFlags = ord($recordData{$pos});
+			$optionFlags = ord($recordData[$pos]);
 			++$pos;
 
 			// bit: 0; mask: 0x01; 0 = compressed; 1 = uncompressed
@@ -2895,7 +2895,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 					// repeated option flags
 					// OpenOffice.org documentation 5.21
-					$option = ord($recordData{$pos});
+					$option = ord($recordData[$pos]);
 					++$pos;
 
 					if ($isCompressed && ($option == 0)) {
@@ -2919,7 +2919,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 						// this fragment compressed
 						$len = min($charsLeft, $limitpos - $pos);
 						for ($j = 0; $j < $len; ++$j) {
-							$retstr .= $recordData{$pos + $j} . chr(0);
+							$retstr .= $recordData[$pos + $j] . chr(0);
 						}
 						$charsLeft -= $len;
 						$isCompressed = false;
@@ -3818,7 +3818,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		// We can apparently not rely on $isPartOfSharedFormula. Even when $isPartOfSharedFormula = true
 		// the formula data may be ordinary formula data, therefore we need to check
 		// explicitly for the tExp token (0x01)
-		$isPartOfSharedFormula = $isPartOfSharedFormula && ord($formulaStructure{2}) == 0x01;
+		$isPartOfSharedFormula = $isPartOfSharedFormula && ord($formulaStructure[2]) == 0x01;
 
 		if ($isPartOfSharedFormula) {
 			// part of shared formula which means there will be a formula with a tExp token and nothing else
@@ -3842,9 +3842,9 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			$xfIndex = self::_GetInt2d($recordData, 4);
 
 			// offset: 6; size: 8; result of the formula
-			if ( (ord($recordData{6}) == 0)
-				&& (ord($recordData{12}) == 255)
-				&& (ord($recordData{13}) == 255) ) {
+			if ( (ord($recordData[6]) == 0)
+				&& (ord($recordData[12]) == 255)
+				&& (ord($recordData[13]) == 255) ) {
 
 				// String formula. Result follows in appended STRING record
 				$dataType = PHPExcel_Cell_DataType::TYPE_STRING;
@@ -3858,25 +3858,25 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 				// read STRING record
 				$value = $this->_readString();
 
-			} elseif ((ord($recordData{6}) == 1)
-				&& (ord($recordData{12}) == 255)
-				&& (ord($recordData{13}) == 255)) {
+			} elseif ((ord($recordData[6]) == 1)
+				&& (ord($recordData[12]) == 255)
+				&& (ord($recordData[13]) == 255)) {
 
 				// Boolean formula. Result is in +2; 0=false, 1=true
 				$dataType = PHPExcel_Cell_DataType::TYPE_BOOL;
-				$value = (bool) ord($recordData{8});
+				$value = (bool) ord($recordData[8]);
 
-			} elseif ((ord($recordData{6}) == 2)
-				&& (ord($recordData{12}) == 255)
-				&& (ord($recordData{13}) == 255)) {
+			} elseif ((ord($recordData[6]) == 2)
+				&& (ord($recordData[12]) == 255)
+				&& (ord($recordData[13]) == 255)) {
 
 				// Error formula. Error code is in +2
 				$dataType = PHPExcel_Cell_DataType::TYPE_ERROR;
-				$value = self::_mapErrorCode(ord($recordData{8}));
+				$value = self::_mapErrorCode(ord($recordData[8]));
 
-			} elseif ((ord($recordData{6}) == 3)
-				&& (ord($recordData{12}) == 255)
-				&& (ord($recordData{13}) == 255)) {
+			} elseif ((ord($recordData[6]) == 3)
+				&& (ord($recordData[12]) == 255)
+				&& (ord($recordData[13]) == 255)) {
 
 				// Formula result is a null string
 				$dataType = PHPExcel_Cell_DataType::TYPE_NULL;
@@ -3944,7 +3944,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		// offset: 6, size: 1; not used
 
 		// offset: 7, size: 1; number of existing FORMULA records for this shared formula
-		$no = ord($recordData{7});
+		$no = ord($recordData[7]);
 
 		// offset: 8, size: var; Binary token array of the shared formula
 		$formula = substr($recordData, 8);
@@ -4011,10 +4011,10 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 			$xfIndex = self::_GetInt2d($recordData, 4);
 
 			// offset: 6; size: 1; the boolean value or error value
-			$boolErr = ord($recordData{6});
+			$boolErr = ord($recordData[6]);
 
 			// offset: 7; size: 1; 0=boolean; 1=error
-			$isError = ord($recordData{7});
+			$isError = ord($recordData[7]);
 
 			$cell = $this->_phpSheet->getCell($columnString . ($row + 1));
 			switch ($isError) {
@@ -4392,7 +4392,7 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 
 		if (!$this->_readDataOnly) {
 			// offset: 0; size: 1; pane identifier
-			$paneId = ord($recordData{0});
+			$paneId = ord($recordData[0]);
 
 			// offset: 1; size: 2; index to row of the active cell
 			$r = self::_GetInt2d($recordData, 1);
@@ -4544,9 +4544,9 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 				$hyperlinkType = 'UNC';
 			} else if (!$isFileLinkOrUrl) {
 				$hyperlinkType = 'workbook';
-			} else if (ord($recordData{$offset}) == 0x03) {
+			} else if (ord($recordData[$offset]) == 0x03) {
 				$hyperlinkType = 'local';
-			} else if (ord($recordData{$offset}) == 0xE0) {
+			} else if (ord($recordData[$offset]) == 0xE0) {
 				$hyperlinkType = 'URL';
 			}
 
@@ -6094,10 +6094,10 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 		$lr = self::_GetInt2d($subData, 2) + 1;
 
 		// offset: 4; size: 1; index to first column
-		$fc = ord($subData{4});
+		$fc = ord($subData[4]);
 
 		// offset: 5; size: 1; index to last column
-		$lc = ord($subData{5});
+		$lc = ord($subData[5]);
 
 		// check values
 		if ($fr > $lr || $fc > $lc) {
@@ -6504,13 +6504,13 @@ class PHPExcel_Reader_Excel5 extends PHPExcel_Reader_Abstract implements PHPExce
 	private static function _readRGB($rgb)
 	{
 		// offset: 0; size 1; Red component
-		$r = ord($rgb{0});
+		$r = ord($rgb[0]);
 
 		// offset: 1; size: 1; Green component
-		$g = ord($rgb{1});
+		$g = ord($rgb[1]);
 
 		// offset: 2; size: 1; Blue component
-		$b = ord($rgb{2});
+		$b = ord($rgb[2]);
 
 		// HEX notation, e.g. 'FF00FC'
 		$rgb = sprintf('%02X%02X%02X', $r, $g, $b);

--- a/Classes/PHPExcel/Reader/Excel5/Escher.php
+++ b/Classes/PHPExcel/Reader/Excel5/Escher.php
@@ -250,16 +250,16 @@ class PHPExcel_Reader_Excel5_Escher
 		$foDelay = PHPExcel_Reader_Excel5::_GetInt4d($recordData, 28);
 
 		// offset: 32; size: 1; unused1
-		$unused1 = ord($recordData{32});
+		$unused1 = ord($recordData[32]);
 
 		// offset: 33; size: 1; size of nameData in bytes (including null terminator)
-		$cbName = ord($recordData{33});
+		$cbName = ord($recordData[33]);
 
 		// offset: 34; size: 1; unused2
-		$unused2 = ord($recordData{34});
+		$unused2 = ord($recordData[34]);
 
 		// offset: 35; size: 1; unused3
-		$unused3 = ord($recordData{35});
+		$unused3 = ord($recordData[35]);
 
 		// offset: 36; size: $cbName; nameData
 		$nameData = substr($recordData, 36, $cbName);
@@ -301,7 +301,7 @@ class PHPExcel_Reader_Excel5_Escher
 		}
 
 		// offset: var; size: 1; tag
-		$tag = ord($recordData{$pos});
+		$tag = ord($recordData[$pos]);
 		$pos += 1;
 
 		// offset: var; size: var; the raw image data
@@ -342,7 +342,7 @@ class PHPExcel_Reader_Excel5_Escher
 		}
 
 		// offset: var; size: 1; tag
-		$tag = ord($recordData{$pos});
+		$tag = ord($recordData[$pos]);
 		$pos += 1;
 
 		// offset: var; size: var; the raw image data

--- a/Classes/PHPExcel/Reader/SYLK.php
+++ b/Classes/PHPExcel/Reader/SYLK.php
@@ -168,7 +168,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 			if ($dataType == 'C') {
 				//  Read cell value data
 				foreach($rowData as $rowDatum) {
-					switch($rowDatum{0}) {
+					switch($rowDatum[0]) {
 						case 'C' :
 						case 'X' :
 							$columnIndex = substr($rowDatum,1) - 1;
@@ -257,7 +257,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 			if ($dataType == 'P') {
 				$formatArray = array();
 				foreach($rowData as $rowDatum) {
-					switch($rowDatum{0}) {
+					switch($rowDatum[0]) {
 						case 'P' :	$formatArray['numberformat']['code'] = str_replace($fromFormats,$toFormats,substr($rowDatum,1));
 									break;
 						case 'E' :
@@ -267,7 +267,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 									break;
 						case 'S' :	$styleSettings = substr($rowDatum,1);
 									for ($i=0;$i<strlen($styleSettings);++$i) {
-										switch ($styleSettings{$i}) {
+										switch ($styleSettings[$i]) {
 											case 'I' :	$formatArray['font']['italic'] = true;
 														break;
 											case 'D' :	$formatArray['font']['bold'] = true;
@@ -291,7 +291,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 				$hasCalculatedValue = false;
 				$cellData = $cellDataFormula = '';
 				foreach($rowData as $rowDatum) {
-					switch($rowDatum{0}) {
+					switch($rowDatum[0]) {
 						case 'C' :
 						case 'X' :	$column = substr($rowDatum,1);
 									break;
@@ -319,12 +319,12 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 												//	Empty R reference is the current row
 												if ($rowReference == '') $rowReference = $row;
 												//	Bracketed R references are relative to the current row
-												if ($rowReference{0} == '[') $rowReference = $row + trim($rowReference,'[]');
+												if ($rowReference[0] == '[') $rowReference = $row + trim($rowReference,'[]');
 												$columnReference = $cellReference[4][0];
 												//	Empty C reference is the current column
 												if ($columnReference == '') $columnReference = $column;
 												//	Bracketed C references are relative to the current column
-												if ($columnReference{0} == '[') $columnReference = $column + trim($columnReference,'[]');
+												if ($columnReference[0] == '[') $columnReference = $column + trim($columnReference,'[]');
 												$A1CellReference = PHPExcel_Cell::stringFromColumnIndex($columnReference-1).$rowReference;
 
 												$value = substr_replace($value,$A1CellReference,$cellReference[0][1],strlen($cellReference[0][0]));
@@ -352,7 +352,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 				$formatStyle = $columnWidth = $styleSettings = '';
 				$styleData = array();
 				foreach($rowData as $rowDatum) {
-					switch($rowDatum{0}) {
+					switch($rowDatum[0]) {
 						case 'C' :
 						case 'X' :	$column = substr($rowDatum,1);
 									break;
@@ -365,7 +365,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 									break;
 						case 'S' :	$styleSettings = substr($rowDatum,1);
 									for ($i=0;$i<strlen($styleSettings);++$i) {
-										switch ($styleSettings{$i}) {
+										switch ($styleSettings[$i]) {
 											case 'I' :	$styleData['font']['italic'] = true;
 														break;
 											case 'D' :	$styleData['font']['bold'] = true;
@@ -408,7 +408,7 @@ class PHPExcel_Reader_SYLK extends PHPExcel_Reader_Abstract implements PHPExcel_
 				}
 			} else {
 				foreach($rowData as $rowDatum) {
-					switch($rowDatum{0}) {
+					switch($rowDatum[0]) {
 						case 'C' :
 						case 'X' :	$column = substr($rowDatum,1);
 									break;

--- a/Classes/PHPExcel/ReferenceHelper.php
+++ b/Classes/PHPExcel/ReferenceHelper.php
@@ -889,9 +889,9 @@ class PHPExcel_ReferenceHelper
 			list($newColumn, $newRow) = PHPExcel_Cell::coordinateFromString( $pCellReference );
 
 			// Verify which parts should be updated
-			$updateColumn = (($newColumn{0} != '$') && ($beforeColumn{0} != '$') &&
+			$updateColumn = (($newColumn[0] != '$') && ($beforeColumn[0] != '$') &&
 							 PHPExcel_Cell::columnIndexFromString($newColumn) >= PHPExcel_Cell::columnIndexFromString($beforeColumn));
-			$updateRow = (($newRow{0} != '$') && ($beforeRow{0} != '$') &&
+			$updateRow = (($newRow[0] != '$') && ($beforeRow[0] != '$') &&
 						  $newRow >= $beforeRow);
 
 			// Create new column reference

--- a/Classes/PHPExcel/Shared/OLE.php
+++ b/Classes/PHPExcel/Shared/OLE.php
@@ -447,7 +447,7 @@ class PHPExcel_Shared_OLE
 	{
 		$rawname = '';
 		for ($i = 0; $i < strlen($ascii); ++$i) {
-			$rawname .= $ascii{$i} . "\x00";
+			$rawname .= $ascii[$i] . "\x00";
 		}
 		return $rawname;
 	}

--- a/Classes/PHPExcel/Shared/String.php
+++ b/Classes/PHPExcel/Shared/String.php
@@ -526,15 +526,15 @@ class PHPExcel_Shared_String
 	 */
 	public static function utf16_decode($str, $bom_be = TRUE) {
 		if( strlen($str) < 2 ) return $str;
-		$c0 = ord($str{0});
-		$c1 = ord($str{1});
+		$c0 = ord($str[0]);
+		$c1 = ord($str[1]);
 		if( $c0 == 0xfe && $c1 == 0xff ) { $str = substr($str,2); }
 		elseif( $c0 == 0xff && $c1 == 0xfe ) { $str = substr($str,2); $bom_be = false; }
 		$len = strlen($str);
 		$newstr = '';
 		for($i=0;$i<$len;$i+=2) {
-			if( $bom_be ) { $val = ord($str{$i})   << 4; $val += ord($str{$i+1}); }
-			else {        $val = ord($str{$i+1}) << 4; $val += ord($str{$i}); }
+			if( $bom_be ) { $val = ord($str[$i])   << 4; $val += ord($str[$i+1]); }
+			else {        $val = ord($str[$i+1]) << 4; $val += ord($str[$i]); }
 			$newstr .= ($val == 0x228) ? "\n" : chr($val);
 		}
 		return $newstr;

--- a/Classes/PHPExcel/Shared/ZipStreamWrapper.php
+++ b/Classes/PHPExcel/Shared/ZipStreamWrapper.php
@@ -81,7 +81,7 @@ class PHPExcel_Shared_ZipStreamWrapper {
      */
     public function stream_open($path, $mode, $options, &$opened_path) {
         // Check for mode
-        if ($mode{0} != 'r') {
+        if ($mode[0] != 'r') {
             throw new PHPExcel_Reader_Exception('Mode ' . $mode . ' is not supported. Only read mode is supported.');
         }
 

--- a/Classes/PHPExcel/Worksheet/AutoFilter.php
+++ b/Classes/PHPExcel/Worksheet/AutoFilter.php
@@ -726,7 +726,7 @@ class PHPExcel_Worksheet_AutoFilter
 							);
 						} else {
 							//	Date based
-							if ($dynamicRuleType{0} == 'M' || $dynamicRuleType{0} == 'Q') {
+							if ($dynamicRuleType[0] == 'M' || $dynamicRuleType[0] == 'Q') {
 								//	Month or Quarter
 								sscanf($dynamicRuleType,'%[A-Z]%d', $periodType, $period);
 								if ($periodType == 'M') {

--- a/Classes/PHPExcel/Writer/Excel5/Parser.php
+++ b/Classes/PHPExcel/Writer/Excel5/Parser.php
@@ -1021,7 +1021,7 @@ class PHPExcel_Writer_Excel5_Parser
 		$col    = 0;
 		$col_ref_length = strlen($col_ref);
 		for ($i = 0; $i < $col_ref_length; ++$i) {
-			$col += (ord($col_ref{$i}) - 64) * pow(26, $expn);
+			$col += (ord($col_ref[$i]) - 64) * pow(26, $expn);
 			--$expn;
 		}
 
@@ -1043,21 +1043,21 @@ class PHPExcel_Writer_Excel5_Parser
 		$formula_length = strlen($this->_formula);
 		// eat up white spaces
 		if ($i < $formula_length) {
-			while ($this->_formula{$i} == " ") {
+			while ($this->_formula[$i] == " ") {
 				++$i;
 			}
 
 			if ($i < ($formula_length - 1)) {
-				$this->_lookahead = $this->_formula{$i+1};
+				$this->_lookahead = $this->_formula[$i+1];
 			}
 			$token = '';
 		}
 
 		while ($i < $formula_length) {
-			$token .= $this->_formula{$i};
+			$token .= $this->_formula[$i];
 
 			if ($i < ($formula_length - 1)) {
-				$this->_lookahead = $this->_formula{$i+1};
+				$this->_lookahead = $this->_formula[$i+1];
 			} else {
 				$this->_lookahead = '';
 			}
@@ -1072,7 +1072,7 @@ class PHPExcel_Writer_Excel5_Parser
 			}
 
 			if ($i < ($formula_length - 2)) {
-				$this->_lookahead = $this->_formula{$i+2};
+				$this->_lookahead = $this->_formula[$i+2];
 			} else { // if we run out of characters _lookahead becomes empty
 				$this->_lookahead = '';
 			}
@@ -1205,7 +1205,7 @@ class PHPExcel_Writer_Excel5_Parser
 	{
 		$this->_current_char = 0;
 		$this->_formula      = $formula;
-		$this->_lookahead    = isset($formula{1}) ? $formula{1} : '';
+		$this->_lookahead    = isset($formula[1]) ? $formula[1] : '';
 		$this->_advance();
 		$this->_parse_tree   = $this->_condition();
 		return true;

--- a/Classes/PHPExcel/Writer/Excel5/Workbook.php
+++ b/Classes/PHPExcel/Writer/Excel5/Workbook.php
@@ -675,7 +675,7 @@ class PHPExcel_Writer_Excel5_Workbook extends PHPExcel_Writer_Excel5_BIFFwriter
 					$formulaData = $this->_parser->toReversePolish();
 
 					// make sure tRef3d is of type tRef3dR (0x3A)
-					if (isset($formulaData{0}) and ($formulaData{0} == "\x7A" or $formulaData{0} == "\x5A")) {
+					if (isset($formulaData[0]) and ($formulaData[0] == "\x7A" or $formulaData[0] == "\x5A")) {
 						$formulaData = "\x3A" . substr($formulaData, 1);
 					}
 

--- a/Classes/PHPExcel/Writer/Excel5/Worksheet.php
+++ b/Classes/PHPExcel/Writer/Excel5/Worksheet.php
@@ -904,7 +904,7 @@ class PHPExcel_Writer_Excel5_Worksheet extends PHPExcel_Writer_Excel5_BIFFwriter
 		$unknown	= 0x0000;			// Must be zero
 
 		// Strip the '=' or '@' sign at the beginning of the formula string
-		if ($formula{0} == '=') {
+		if ($formula[0] == '=') {
 			$formula = substr($formula,1);
 		} else {
 			// Error handling


### PR DESCRIPTION
Replaced curly braces in PHPExcel with square brackets. PHPExcel now passes PHP 8 lint (php -l). Has not been tested.