### PR TITLE
replaced curly braces in barcodepack for PHP 8 compat

### DIFF
--- a/includes/barcodepack/class.code128.php
+++ b/includes/barcodepack/class.code128.php
@@ -230,18 +230,18 @@ class code128 extends linearBarcode {
 
 		$biteCode['DATA'] = '';
 		// Find start character
-		if(strlen($this->text)>=2 && is_numeric($this->text{0}) && is_numeric($this->text{1})) {
+		if(strlen($this->text)>=2 && is_numeric($this->text[0]) && is_numeric($this->text[1])) {
 			// If the first and second characters are numeric use character set C
 			// and insert START_C char
 			$biteCode['DATA'] .= $this->codeTable[self::START_C];
 			$characterSet = self::CHARSET_C;
 			$weightedSum += self::START_C;
-		} else if (strpos ($this->charsB, $this->text{0})) {
+		} else if (strpos ($this->charsB, $this->text[0])) {
 			// Character set B
 			$biteCode['DATA'] .= $this->codeTable[self::START_B];
 			$characterSet = self::CHARSET_B;
 			$weightedSum += self::START_B;
-		} else if (strpos ($this->charsA, $this->text{0})) {
+		} else if (strpos ($this->charsA, $this->text[0])) {
 			// Character set A
 			$biteCode['DATA'] .= $this->codeTable[self::START_A];
 			$characterSet = self::CHARSET_A;
@@ -255,17 +255,17 @@ class code128 extends linearBarcode {
 			switch ($characterSet) {
 				case 'B':
 					// Character set B is default, so it is first
-					$characterValue = $this->setB[ord($this->text{$i})];
+					$characterValue = $this->setB[ord($this->text[$i])];
 					$biteCode['DATA'] .= $this->codeTable[$characterValue];
 					break;
 
 				case 'A':
-					$characterValue = $this->setA[ord($this->text{$i})];
+					$characterValue = $this->setA[ord($this->text[$i])];
 					$biteCode['DATA'] .= $this->codeTable[$characterValue];
 					break;
 
 				case 'C':
-					$characterValue = intval($this->text{$i}.$this->text{$i+1});
+					$characterValue = intval($this->text[$i].$this->text[$i+1]);
 					$biteCode['DATA'] .= $this->codeTable[$characterValue];
 					$i++;
 					break;
@@ -278,7 +278,7 @@ class code128 extends linearBarcode {
 			$checksumCounter++;
 
 			// find next char set.
-			if(strlen($this->text) > ($i+2) && is_numeric($this->text{$i+1}) && is_numeric($this->text{$i+2})) {
+			if(strlen($this->text) > ($i+2) && is_numeric($this->text[$i+1]) && is_numeric($this->text[$i+2])) {
 				if($characterSet!=self::CHARSET_C) {
 					$characterValue = 99;
 					$biteCode['DATA'] .= $this->codeTable[$characterValue];
@@ -287,7 +287,7 @@ class code128 extends linearBarcode {
 				}
 				$characterSet = 'C';
 			} else if(isset($this->text{$i+1})) {
-				$newCharacterSet = $this->findCharacterSet($this->text{$i+1});
+				$newCharacterSet = $this->findCharacterSet($this->text[$i+1]);
 				if($characterSet==self::CHARSET_C) {
 					if($newCharacterSet==self::CHARSET_A) {
 						$characterValue = 101;

--- a/includes/barcodepack/class.ean13.php
+++ b/includes/barcodepack/class.ean13.php
@@ -98,12 +98,12 @@ class ean13 extends linearBarcode {
 		$saveTo = 'DATA';
 
 		// Parity determine
-		$parity = $this->parity[$this->text{0}];
+		$parity = $this->parity[$this->text[0]];
 
 		$biteCode['START'] = $this->codeTable['START'];
 
 		for($i=1;$i<strlen($this->text);$i++) {
-			$biteCode[$saveTo] .= $this->codeTable[$this->text{$i}][$parity{$i-1}];
+			$biteCode[$saveTo] .= $this->codeTable[$this->text[$i]][$parity[$i-1]];
 			if($i==6) {
 				$biteCode['SEPARATOR'] = $this->codeTable['SEPARATOR'];
 				$saveTo = 'DATA2';
@@ -137,9 +137,9 @@ class ean13 extends linearBarcode {
 
 		for($i=1;$i<=strlen($text);$i++) {
 			if($i%2==0) {
-				$evensum += (int) $text{$i-1};
+				$evensum += (int) $text[$i-1];
 			} else {
-				$oddsum += (int) $text{$i-1};
+				$oddsum += (int) $text[$i-1];
 			}
 		}
 
@@ -175,12 +175,12 @@ class ean13 extends linearBarcode {
 			imagecopy($im2, $im, $margin, 0, 0, 0, $this->getBarcodeLen()*$this->moduleSize+(2*$margin), $this->height+$this->fontSize+(2*$margin));
 
 			// Divide text into three parts and each insert to the diffrerent place
-			$charsA = $this->text{0};	// first char
+			$charsA = $this->text[0];	// first char
 			for($i=1;$i<=strlen($this->text);$i++) {
 				if($i<=6) {
-					$charsB .= $this->text{$i};
+					$charsB .= $this->text[$i];
 				} else {
-					$charsC .= $this->text{$i};
+					$charsC .= $this->text[$i];
 				}
 			}
 

--- a/includes/barcodepack/class.i2of5.php
+++ b/includes/barcodepack/class.i2of5.php
@@ -101,7 +101,7 @@ class i2of5 extends linearBarcode {
 				// Encode first char into lines
 				$bars = true;
 				while($bars && $firstCounter<13) {
-					if($this->codeTable[$this->text{$i}]{$firstCounter}=="1") {
+					if($this->codeTable[$this->text[$i]][$firstCounter]=="1") {
 						$biteCode['DATA'] .= '1';	// line
 					} else {
 						$bars = false;
@@ -112,7 +112,7 @@ class i2of5 extends linearBarcode {
 				// Second char is encoded to spaces
 				$spaces = true;
 				while($spaces && $secondCounter<13) {
-					if($this->codeTable[$this->text{$i+1}]{$secondCounter}=='1') {
+					if($this->codeTable[$this->text[$i+1]][$secondCounter]=='1') {
 						$biteCode['DATA'] .= '0';	// space
 						$secondCounter++;
 					} else {

--- a/includes/barcodepack/class.linearBarcode.php
+++ b/includes/barcodepack/class.linearBarcode.php
@@ -70,7 +70,7 @@ class linearBarcode extends barcode {
 	protected function checkAllowedChars($text, $allowedChars)
 	{
 		for($i=0; $i<strlen($text); $i++) {
-			if(!in_array($text{$i}, $allowedChars)) {
+			if(!in_array($text[$i], $allowedChars)) {
 				throw new Exception('Input text contains nonallowed characters.', E_BAD_CHARS);
 				return false;
 			}
@@ -120,7 +120,7 @@ class linearBarcode extends barcode {
 				case 'DATA2':
 					// Data
 					for($i=0;$i<strlen($values);$i++) {
-						$color = (($values{$i})=='1') ? $black : $white;
+						$color = (($values[$i])=='1') ? $black : $white;
 						imagefilledrectangle($im, $pos*$this->moduleSize+$margin, $margin,
 								($pos+1)*$this->moduleSize+$margin,
 								$this->height-5*$this->moduleSize+$margin, $color);
@@ -132,7 +132,7 @@ class linearBarcode extends barcode {
 					// will be longer
 					for($i=0;$i<strlen($values);$i++) {
 
-						$color = (($values{$i})=='1') ? $black : $white;
+						$color = (($values[$i])=='1') ? $black : $white;
 						imagefilledrectangle($im, $pos*$this->moduleSize+$margin, $margin,
 								($pos+1)*$this->moduleSize+$margin, $this->height+$margin,
 								$color);

--- a/includes/barcodepack/class.qrCode.php
+++ b/includes/barcodepack/class.qrCode.php
@@ -751,13 +751,13 @@ class qrCode extends barcode {
 					if($i%2==0) {
 						$data[$dataCounter] = array(
 							6,
-							$this->alphanumCodingTable[$text{$i}],
+							$this->alphanumCodingTable[$text[$i]],
 						);
 						$addToTotalData = 6;
 					} else {
 						$data[$dataCounter] = array(
 							11,
-							$data[$dataCounter][1]*45 + $this->alphanumCodingTable[$text{$i}],
+							$data[$dataCounter][1]*45 + $this->alphanumCodingTable[$text[$i]],
 
 						);
 						$totalDataBits += 11;
@@ -777,7 +777,7 @@ class qrCode extends barcode {
 					for($i=0;$i<$this->charsNum;$i++) {
 						$data[] = array(
 							8,
-							ord($text{$i}),
+							ord($text[$i]),
 						);
 						$totalDataBits += 8;
 					}

--- a/includes/barcodepack/class.s2of5.php
+++ b/includes/barcodepack/class.s2of5.php
@@ -83,7 +83,7 @@ class s2of5 extends linearBarcode {
 		// Input data encode
 		$biteCode['DATA'] = '';
 		for($i=0;$i<strlen($this->text);$i++) {
-			$biteCode['DATA'] .= $this->codeTable[$this->text{$i}];
+			$biteCode['DATA'] .= $this->codeTable[$this->text[$i]];
 		}
 
 		// STOP char

--- a/includes/barcodepack/class.upc.php
+++ b/includes/barcodepack/class.upc.php
@@ -109,12 +109,12 @@ class upc extends linearBarcode {
 		$saveTo = 'DATA';
 
 		// Parity determine
-		$parity = $this->parity[$this->text{0}];
+		$parity = $this->parity[$this->text[0]];
 
 		$biteCode['START'] = $this->codeTable['START'];
 
 		for($i=1;$i<strlen($this->text);$i++) {
-			$biteCode[$saveTo] .= $this->codeTable[$this->text{$i}][$parity{$i-1}];
+			$biteCode[$saveTo] .= $this->codeTable[$this->text[$i]][$parity[$i-1]];
 			if($i==6) {
 				$biteCode['SEPARATOR'] = $this->codeTable['SEPARATOR'];
 				$saveTo = 'DATA2';
@@ -147,9 +147,9 @@ class upc extends linearBarcode {
 
 		for($i=1;$i<=strlen($text);$i++) {
 			if($i%2==0) {
-				$evensum += (int) $text{$i-1};
+				$evensum += (int) $text[$i-1];
 			} else {
-				$oddsum += (int) $text{$i-1};
+				$oddsum += (int) $text[$i-1];
 			}
 		}
 
@@ -182,12 +182,12 @@ class upc extends linearBarcode {
 
 			imagecopy($im2, $im, $margin, 0, 0, 0, $this->getBarcodeLen()*$this->moduleSize+(2*$margin), $this->height+$this->fontSize+(2*$margin));
 
-			$charsA = $this->text{0};
+			$charsA = $this->text[0];
 			for($i=1;$i<=strlen($this->text);$i++) {
 				if($i<=6) {
-					$charsB .= $this->text{$i};
+					$charsB .= $this->text[$i];
 				} else {
-					$charsC .= $this->text{$i};
+					$charsC .= $this->text[$i];
 				}
 			}
 


### PR DESCRIPTION
Replaced curly braces in barcodepack with square brackets for PHP 8.0 compatibility, now passes PHP 8 lint (php -l). Has not been tested.